### PR TITLE
Adds Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,19 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>com.premiumminds.wicket.crudifier</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>com.mycila.maven-license-plugin</groupId>
 				<artifactId>maven-license-plugin</artifactId>
 				<version>1.10.b1</version>


### PR DESCRIPTION
Allows for easier migration to java modules by reserving the module name now and not rely on the jar filename.

fixes #82 